### PR TITLE
Fix rules_extraction notebook to optionally run on CPU

### DIFF
--- a/use_case_sport_classification/rules_extraction_demo.ipynb
+++ b/use_case_sport_classification/rules_extraction_demo.ipynb
@@ -95,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = DataProcessor(model = model, train_dataloader = train_loader, test_dataloader = test_loader)"
+    "data = DataProcessor(model = model, train_dataloader = train_loader, test_dataloader = test_loader, device = device)"
    ]
   },
   {


### PR DESCRIPTION
* Add missing DataProcessor parameter to allow the notebook to run
  on CPU in case the GPU (cuda) is not available.
